### PR TITLE
add official nest compile step & remove now-redundant decorators

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,9 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "plugins": ["@nestjs/swagger/plugin"]
+    "plugins": [
+      "@nestjs/swagger/plugin",
+      "@nestjs/graphql/plugin"
+    ]
   }
 }

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -14,20 +14,10 @@ registerEnumType(Role, {
 
 @ObjectType()
 export class User extends Model {
-  @Field((type) => String)
   email: string;
-
-  @Field((type) => String, { nullable: true })
   firstname?: string;
-
-  @Field((type) => String, { nullable: true })
   lastname?: string;
-
-  @Field((type) => Role)
   role: Role;
-
-  @Field((type) => [Post])
   posts: Post[];
-
   password: string;
 }


### PR DESCRIPTION
Love the starter pack - great job! Have you considered cleaning up the models/etc by using the official plugin that auto-adds them? I only provided one example in this PR, but I'm willing to update all. Not sure if there was reason you didn't use! 

Talks about it in NestJS 7 announcement here:
https://trilon.io/blog/announcing-nestjs-7-whats-new#NestJS-GraphQL-Plugin

And also here in the documentation (under CLI plugin🤔): 
https://docs.nestjs.com/graphql/resolvers#cli-plugin