### PR TITLE
Add nest7 new decorator syntax

### DIFF
--- a/src/decorators/user.decorator.ts
+++ b/src/decorators/user.decorator.ts
@@ -1,10 +1,11 @@
-import { createParamDecorator } from '@nestjs/common';
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { User } from '../models/user';
 
 export function getUser(ctx): User {
-  return ctx.req.user;
+  const request = ctx.switchToHttp().getNext();
+  return request.req.user;
 }
 
 export const UserEntity = createParamDecorator(
-  (data, [root, args, ctx, info]) => getUser(ctx)
+  (data, ctx: ExecutionContext) => getUser(ctx)
 );

--- a/src/decorators/user.decorator.ts
+++ b/src/decorators/user.decorator.ts
@@ -2,8 +2,8 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { User } from '../models/user';
 
 export function getUser(ctx): User {
-  const request = ctx.switchToHttp().getNext();
-  return request.req.user;
+  const request = ctx.switchToHttp().getNext().req;
+  return request.user;
 }
 
 export const UserEntity = createParamDecorator(


### PR DESCRIPTION
With old syntax nest throw error.

I tried to write as written in the documentation of [Custom route decorators](https://docs.nestjs.com/custom-decorators#custom-route-decorators) like this:
```js
const request = ctx.switchToHttp().getRequest();
return request.user;
```

but i got `request.user` is undefined.

So I find the user through the `getNext().req`