### PR TITLE
Make cursors nullable to cater for empty array

### DIFF
--- a/src/common/pagination/page-info.ts
+++ b/src/common/pagination/page-info.ts
@@ -2,8 +2,8 @@ import { Field, ObjectType } from '@nestjs/graphql';
 
 @ObjectType()
 export class PageInfo {
-  @Field((type) => String)
-  endCursor: string;
+  @Field((type) => String, { nullable: true })
+  endCursor?: string;
 
   @Field((type) => Boolean)
   hasNextPage: boolean;
@@ -11,6 +11,6 @@ export class PageInfo {
   @Field((type) => Boolean)
   hasPreviousPage: boolean;
 
-  @Field((type) => String)
-  startCursor: string;
+  @Field((type) => String, { nullable: true })
+  startCursor?: string;
 }


### PR DESCRIPTION
Currently the schema does not allow for null cursors on empty arrays, and fails when the array is empty. 

I am using this as a baseline in a different repository, and don't currently use prisma2. I am not 100% sure what prisma returns in this case and cannot test it easily.

Will see if I can find typings online, but putting this PR in so long since it might be useful in the Prisma case as well.