### PR TITLE
Update deprecated methods

### DIFF
--- a/src/services/prisma.service.ts
+++ b/src/services/prisma.service.ts
@@ -8,10 +8,10 @@ export class PrismaService extends PrismaClient
     super();
   }
   async onModuleInit() {
-    await this.connect();
+    await this.$connect();
   }
 
   async onModuleDestroy() {
-    await this.disconnect();
+    await this.$disconnect();
   }
 }


### PR DESCRIPTION
https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/connection-management
The connect() and disconnect() have been renamed to $connect() and $disconnect().