### PR TITLE
update docker-compose.yml postgres version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - .env
 
   postgres:
-    image: postgres:12
+    image: postgres:13
     container_name: postgres
     restart: always
     ports:


### PR DESCRIPTION
hey!

I see that docker-compose.db.yml uses postgresql v13 but docker-compose.yml uses v12.

this MR will make both have the same version.