### PR TITLE
fix: add dotenv in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chance": "1.1.7",
+    "dotenv": "^10.0.0",
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-prettier": "3.4.0",


### PR DESCRIPTION
Running seed after setting up project leads to this error,
```bash

Environment variables loaded from .env
Prisma schema loaded from prisma/schema.prisma
Running seed from prisma/seed.ts ...
Result:
prisma/seed.ts:2:25 - error TS2307: Cannot find module 'dotenv' or its corresponding type declarations.

2 import \* as dotenv from 'dotenv';
~~~~~~~~

Error: Command failed with exit code 1: ts-node --eval "
// @ts-ignore
declare const require: any

console.info('Result:')

const **seed = require('./prisma/seed.ts')
const **keys = Object.keys(\_\_seed)

async function runSeed() {
// Execute "seed" named export or default export
if (**keys && **keys.length) {
if (**keys.indexOf('seed') !== -1) {
return **seed.seed()
} else if (**keys.indexOf('default') !== -1) {
return **seed.default()
}
}
}

runSeed()
.then(function (result) {
if (result) {
console.log(result)
}
})
.catch(function (e) {
console.error('Error from seed:')
throw e
})
```
---
Adding dotenv as a devDependency fixes this issue